### PR TITLE
perf: -msse3 flag may add ~5-6% improved runtime

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setuptools.setup(
       language='c++',
       include_dirs=[ np.get_include() ],
       extra_compile_args=[
-        '-std=c++11', '-O3', '-ffast-math'
+        '-std=c++11', '-O3', '-ffast-math', 
+        '-msse3'
       ]
     )
   ],


### PR DESCRIPTION
Tested float32 data vs uint8 data. float32 seemed to improve, uint8 was about the same.

sse3 was introduced in 2003, so it's probably safe to assume x86_64 architectures support it.