### PR TITLE
feat: add dijkstra_anisotropy to support anisotropy in 3d dijkstra field

### DIFF
--- a/dijkstra3d.hpp
+++ b/dijkstra3d.hpp
@@ -44,6 +44,13 @@ inline float _c(const float wa, const float wb, const float wc) {
   return std::sqrt(wa * wa + wb * wb + wc * wc);
 }
 
+// helper function to compute cross product
+inline float _cross(const float sx, const float sy, const float sz, 
+const float tx, const float ty, const float tz) {
+  return std::sqrt((sy*tz - sz*ty) * (sy*tz - sz*ty) + (sz*tx - sx*tz) * (sz*tx - sx*tz) + (sx*ty - sy*tx) * (sx*ty - sy*tx) / 
+          std::sqrt(sx*sx + sy*sy + sz*sz) / std::sqrt(tx*tx + ty*ty + tz*tz));
+}
+
 inline float* fill(float *arr, const float value, const size_t size) {
   for (size_t i = 0; i < size; i++) {
     arr[i] = value;
@@ -1104,6 +1111,183 @@ std::vector<OUT> compass_guided_dijkstra3d(
 
   return path;
 }
+
+template <typename T, typename OUT = uint32_t>
+std::vector<OUT> compass_guided_dijkstra3d_anisotropy_line_preference(
+    T* field, 
+    const size_t sx, const size_t sy, const size_t sz, 
+    const size_t source, const size_t target,
+    const int connectivity = 26, float normalizer = -1,
+    float line_preference_weight = 1.0,
+    const float wx = 1.0, const float wy = 1.0, const float wz = 1.0,
+    const uint32_t* voxel_connectivity_graph = NULL
+  ) {
+
+  connectivity_check(connectivity);
+
+  if (source == target) {
+    return std::vector<OUT>{ static_cast<OUT>(source) };
+  }
+
+  const size_t voxels = sx * sy * sz;
+  const size_t sxy = sx * sy;
+  
+  const libdivide::divider<size_t> fast_sx(sx); 
+  const libdivide::divider<size_t> fast_sxy(sxy); 
+
+  const bool power_of_two = !((sx & (sx - 1)) || (sy & (sy - 1))); 
+  const int xshift = std::log2(sx); // must use log2 here, not lg/lg2 to avoid fp errors
+  const int yshift = std::log2(sy);
+
+  float *dist = new float[voxels]();
+  OUT *parents = new OUT[voxels]();
+  fill(dist, +INFINITY, voxels);
+  dist[source] = 0;
+
+  // Normalizer value must be positive. 
+  // If negative, use min field value.
+  if (normalizer < 0) {
+    normalizer = static_cast<float>(field[0]);
+    for (size_t i = 0; i < voxels; i++) {
+      if (normalizer > static_cast<float>(field[i])) {
+        normalizer = static_cast<float>(field[i]);
+      }
+    }
+  }
+
+  int neighborhood[NHOOD_SIZE];
+
+  float neighbor_multiplier[NHOOD_SIZE] = { 
+    wx, wx, wy, wy, wz, wz, // axial directions (6)
+    
+    // square diagonals (12)
+    _s(wx, wy), _s(wx, wy), _s(wx, wy), _s(wx, wy),  
+    _s(wy, wz), _s(wy, wz), _s(wy, wz), _s(wy, wz),
+    _s(wx, wz), _s(wx, wz), _s(wx, wz), _s(wx, wz),
+
+    // cube diagonals (8)
+    _c(wx, wy, wz), _c(wx, wy, wz), _c(wx, wy, wz), _c(wx, wy, wz), 
+    _c(wx, wy, wz), _c(wx, wy, wz), _c(wx, wy, wz), _c(wx, wy, wz)
+  };
+
+  std::priority_queue<HeapNode<OUT>, std::vector<HeapNode<OUT>>, HeapNodeCompare<OUT>> queue;
+  queue.emplace(0.0, source);
+
+  size_t loc;
+  float delta;
+  size_t neighboridx;
+
+  int x, y, z;
+  int srcx, srcy, srcz;
+  int tx, ty, tz;
+  float heuristic_cost;
+  bool target_reached = false;
+
+  tz = target / fast_sxy;
+  ty = (target - (tz * sxy)) / fast_sx;
+  tx = target - sx * (ty + tz * sy);
+
+  srcz = source / fast_sxy;
+  srcy = (source - (srcz * sxy)) / fast_sx;
+  srcx = source - sx * (srcy + srcz * sy);
+
+  std::function<void(size_t)> xyzfn = [&x,&y,&z,power_of_two,xshift,yshift,sx,sy,sxy,fast_sx,fast_sxy](size_t l){
+    if (power_of_two) {
+      z = l >> (xshift + yshift);
+      y = (l - (z << (xshift + yshift))) >> xshift;
+      x = l - ((y + (z << yshift)) << xshift);
+    }
+    else {
+      z = l / fast_sxy;
+      y = (l - (z * sxy)) / fast_sx;
+      x = l - sx * (y + z * sy);
+    }
+  };
+
+  while (!queue.empty()) {
+    loc = queue.top().value;
+    queue.pop();
+    
+    if (std::signbit(dist[loc])) {
+      continue;
+    }
+
+    DIJKSTRA_3D_PREFETCH_26WAY(field, loc)
+    DIJKSTRA_3D_PREFETCH_26WAY(dist, loc)
+
+    xyzfn(loc);
+
+    compute_neighborhood(neighborhood, x, y, z, sx, sy, sz, connectivity, voxel_connectivity_graph);
+
+    for (int i = 0; i < connectivity; i++) {
+      if (neighborhood[i] == 0) {
+        continue;
+      }
+
+      neighboridx = loc + neighborhood[i];
+      delta = static_cast<float>(field[neighboridx]) * neighbor_multiplier[i];
+
+      // Visited nodes are negative and thus the current node
+      // will always be less than as field is filled with non-negative
+      // integers.
+      if (dist[loc] + delta < dist[neighboridx]) { 
+        dist[neighboridx] = dist[loc] + delta;
+        parents[neighboridx] = loc + 1; // +1 to avoid 0 ambiguity
+
+        if (neighboridx == target) {
+          target_reached = true;
+          goto OUTSIDE;
+        }
+
+        xyzfn(neighboridx);
+
+        if (connectivity == 6) { // manhattan (L_1)
+          heuristic_cost = static_cast<float>(
+            abs(tx - x) * wx + abs(ty - y) * wy + abs(tz - z) * wz
+          );
+        }
+        else if (connectivity == 18) {
+          // The faces + edges case is weird... 
+          // It's 8 connected on each plane, but you can't
+          // move diagonally in 3D.
+          heuristic_cost = static_cast<float>(
+            std::min(
+              std::min(
+                std::max(abs(tx - x) * wx, abs(ty - y) * wy) + abs(tz - z) * wz,
+                std::max(abs(tx - x) * wx, abs(tz - z) * wz) + abs(ty - y) * wy
+              ),
+              std::max(abs(ty - y) * wy, abs(tz - z) * wz) + abs(tx - x) * wx
+            )
+          );
+        }
+        else { // chebychev (L_inf)
+          heuristic_cost = static_cast<float>(
+            std::max(std::max(abs(tx - x) * wx, abs(ty - y) * wy), abs(tz - z) * wz)
+          );
+        }
+
+        // weight the heuristic_cost with cross product
+        heuristic_cost += _cross((tx - srcx) * wx, (ty - srcy) * wy, (tz - srcz) * wz, 
+                                 (tx - x) * wx, (ty - y) * wy, (tz - z) * wz) * line_preference_weight;
+        queue.emplace(dist[neighboridx] + normalizer * heuristic_cost, neighboridx);
+      }
+    }
+
+    dist[loc] *= -1;
+  }
+
+  OUTSIDE:
+  delete []dist;
+
+  std::vector<OUT> path;
+  if (target_reached) {
+    path = query_shortest_path<OUT>(parents, target);
+  }
+  delete [] parents;
+
+  return path;
+}
+
 
 
 template <typename T, typename OUT = uint32_t>

--- a/dijkstra3d.pyx
+++ b/dijkstra3d.pyx
@@ -35,8 +35,9 @@ import sys
 from libcpp.vector cimport vector
 cimport numpy as cnp
 import numpy as np
+import warnings
 
-__VERSION__ = '1.13.0'
+__VERSION__ = '1.14.0.dev0'
 
 ctypedef fused UINT:
   uint8_t
@@ -53,6 +54,14 @@ cdef extern from "dijkstra3d.hpp" namespace "dijkstra":
     size_t sx, size_t sy, size_t sz, 
     size_t source, size_t target,
     int connectivity, uint32_t* voxel_graph
+  )
+  cdef vector[OUT] dijkstra3d_anisotropy[T,OUT](
+    T* field, 
+    size_t sx, size_t sy, size_t sz, 
+    size_t source, size_t target,
+    int connectivity,
+    float wx, float wy, float wz,
+    uint32_t* voxel_graph
   )
   cdef vector[OUT] binary_dijkstra3d[OUT](
     uint8_t* field, 
@@ -123,7 +132,8 @@ def dijkstra(
   data, source, target, 
   bidirectional=False, connectivity=26, 
   compass=False, compass_norm=-1,
-  voxel_graph=None
+  voxel_graph=None,
+  anisotropy=None
 ):
   """
   Perform dijkstra's shortest path algorithm
@@ -201,12 +211,20 @@ def dijkstra(
   cdef size_t rows = data.shape[1]
   cdef size_t depth = data.shape[2]
 
-  path = _execute_dijkstra(
-    data, source, target, connectivity, 
-    bidirectional, compass, compass_norm,
-    voxel_graph
-  )
-
+  if anisotropy is None:
+    path = _execute_dijkstra(
+      data, source, target, connectivity, 
+      bidirectional, compass, compass_norm,
+      voxel_graph
+    )
+  else:
+    if bidirectional or compass:
+      warnings.warn("bidirectional = True or compass = True is not currently supported by \
+anisotropy dijkstra3d. Fall back to vanilla dijkstra algorithm.")
+    path = _execute_dijkstra_anisotropy(
+      data, source, target, connectivity,
+      anisotropy, voxel_graph
+    )
   return _path_to_point_cloud(path, dims, rows, cols)
 
 def railroad(
@@ -815,7 +833,7 @@ def _execute_value_target_dijkstra(
 def _execute_dijkstra(
   data, source, target, int connectivity, 
   bidirectional, compass, float compass_norm=-1,
-  voxel_graph=None
+  voxel_graph=None, anisotropy=None
 ):
   cdef uint8_t[:,:,:] arr_memview8
   cdef uint16_t[:,:,:] arr_memview16
@@ -1164,6 +1182,173 @@ def _execute_dijkstra(
     return output
   else:
     return output[::-1]
+
+def _execute_dijkstra_anisotropy(
+  data, source, target, int connectivity, 
+  anisotropy, voxel_graph=None, 
+):
+  cdef uint8_t[:,:,:] arr_memview8
+  cdef uint16_t[:,:,:] arr_memview16
+  cdef uint32_t[:,:,:] arr_memview32
+  cdef uint64_t[:,:,:] arr_memview64
+  cdef float[:,:,:] arr_memviewfloat
+  cdef double[:,:,:] arr_memviewdouble
+
+  cdef uint32_t[:,:,:] voxel_graph_memview
+  cdef uint32_t* voxel_graph_ptr = NULL
+  if voxel_graph is not None:
+    voxel_graph_memview = voxel_graph
+    voxel_graph_ptr = <uint32_t*>&voxel_graph_memview[0,0,0]
+
+  cdef size_t sx = data.shape[0]
+  cdef size_t sy = data.shape[1]
+  cdef size_t sz = data.shape[2]
+
+  cdef float wx = anisotropy[0]
+  cdef float wy = anisotropy[1]
+  cdef float wz = anisotropy[2]
+
+  cdef size_t src = source[0] + sx * (source[1] + sy * source[2])
+  cdef size_t sink = target[0] + sx * (target[1] + sy * target[2])
+
+  cdef vector[uint32_t] output32
+  cdef vector[uint64_t] output64
+
+  sixtyfourbit = data.size > np.iinfo(np.uint32).max
+  
+  dtype = data.dtype
+
+  if dtype == np.float32:
+    arr_memviewfloat = data
+    if sixtyfourbit:
+      output64 = dijkstra3d_anisotropy[float, uint64_t](
+        &arr_memviewfloat[0,0,0],
+        sx, sy, sz,
+        src, sink, connectivity,
+        wx, wy, wz,
+        voxel_graph_ptr
+      )
+    else:
+      output32 = dijkstra3d_anisotropy[float, uint32_t](
+        &arr_memviewfloat[0,0,0],
+        sx, sy, sz,
+        src, sink, connectivity,
+        wx, wy, wz,
+        voxel_graph_ptr
+      )
+  elif dtype == np.float64:
+    arr_memviewdouble = data
+    if sixtyfourbit:
+      output64 = dijkstra3d_anisotropy[double, uint64_t](
+        &arr_memviewdouble[0,0,0],
+        sx, sy, sz,
+        src, sink, connectivity,
+        wx, wy, wz,
+        voxel_graph_ptr
+      )
+    else:
+      output32 = dijkstra3d_anisotropy[double, uint32_t](
+        &arr_memviewdouble[0,0,0],
+        sx, sy, sz,
+        src, sink, connectivity,
+        wx, wy, wz,
+        voxel_graph_ptr
+      )
+  elif dtype in (np.int64, np.uint64):
+    arr_memview64 = data.view(np.uint64)
+    if sixtyfourbit:
+      output64 = dijkstra3d_anisotropy[uint64_t, uint64_t](
+        &arr_memview64[0,0,0],
+        sx, sy, sz,
+        src, sink, connectivity,
+        wx, wy, wz,
+        voxel_graph_ptr
+      )
+    else:
+      output32 = dijkstra3d_anisotropy[uint64_t, uint32_t](
+        &arr_memview64[0,0,0],
+        sx, sy, sz,
+        src, sink, connectivity,
+        wx, wy, wz,
+        voxel_graph_ptr
+      )
+  elif dtype in (np.int32, np.uint32):
+    arr_memview32 = data.view(np.uint32)
+    if sixtyfourbit:
+      output64 = dijkstra3d_anisotropy[uint32_t, uint64_t](
+        &arr_memview32[0,0,0],
+        sx, sy, sz,
+        src, sink, connectivity,
+        wx, wy, wz,
+        voxel_graph_ptr
+      )
+    else:
+      output32 = dijkstra3d_anisotropy[uint32_t, uint32_t](
+        &arr_memview32[0,0,0],
+        sx, sy, sz,
+        src, sink, connectivity,
+        wx, wy, wz,
+        voxel_graph_ptr
+      )
+  elif dtype in (np.int16, np.uint16):
+    arr_memview16 = data.view(np.uint16)
+    if sixtyfourbit:
+      output64 = dijkstra3d_anisotropy[uint16_t, uint64_t](
+        &arr_memview16[0,0,0],
+        sx, sy, sz,
+        src, sink, connectivity,
+        wx, wy, wz,
+        voxel_graph_ptr
+      )
+    else:
+      output32 = dijkstra3d_anisotropy[uint16_t, uint32_t](
+        &arr_memview16[0,0,0],
+        sx, sy, sz,
+        src, sink, connectivity,
+        wx, wy, wz,
+        voxel_graph_ptr
+      )
+  elif dtype in (np.int8, np.uint8, bool):
+    arr_memview8 = data.view(np.uint8)
+    if sixtyfourbit:
+      output64 = dijkstra3d_anisotropy[uint8_t, uint64_t](
+        &arr_memview8[0,0,0],
+        sx, sy, sz,
+        src, sink, connectivity,
+        wx, wy, wz,
+        voxel_graph_ptr
+      )
+    else:
+      output32 = dijkstra3d_anisotropy[uint8_t, uint32_t](
+        &arr_memview8[0,0,0],
+        sx, sy, sz,
+        src, sink, connectivity,
+        wx, wy, wz,
+        voxel_graph_ptr
+      )
+
+  cdef uint32_t* output_ptr32
+  cdef uint64_t* output_ptr64
+
+  cdef uint32_t[:] vec_view32
+  cdef uint64_t[:] vec_view64
+
+  if sixtyfourbit:
+    output_ptr64 = <uint64_t*>&output64[0]
+    if output64.size() == 0:
+      return np.zeros((0,), dtype=np.uint64)
+    vec_view64 = <uint64_t[:output64.size()]>output_ptr64
+    buf = bytearray(vec_view64[:])
+    output = np.frombuffer(buf, dtype=np.uint64)
+  else:
+    output_ptr32 = <uint32_t*>&output32[0]
+    if output32.size() == 0:
+      return np.zeros((0,), dtype=np.uint32)
+    vec_view32 = <uint32_t[:output32.size()]>output_ptr32
+    buf = bytearray(vec_view32[:])
+    output = np.frombuffer(buf, dtype=np.uint32)
+
+  return output[::-1]
 
 def _execute_binary_dijkstra(
   data, source, target, int connectivity,

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if sys.platform == 'darwin':
 
 setuptools.setup(
   name="dijkstra3d",
-  version="1.13.0",
+  version="1.14.0.dev0",
   python_requires=">=3.7,<4.0",
   setup_requires=['numpy','cython'],
   ext_modules=[

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if sys.platform == 'darwin':
 
 setuptools.setup(
   name="dijkstra3d",
-  version="1.14.0.dev0",
+  version="1.14.0.dev1",
   python_requires=">=3.7,<4.0",
   setup_requires=['numpy','cython'],
   ext_modules=[


### PR DESCRIPTION
Test:

```{python}
import matplotlib.pyplot as plt
import numpy as np
import cv2
import dijkstra3d

def arclen(pnts):
    return np.sum(np.linalg.norm(np.diff(pnts.astype('float'), axis=0), axis=1))

weight = np.ones([1, 50, 50])
stPnt = [0, 0, 0]
edPnt = [0, 30, 49]
path = dijkstra3d.dijkstra(weight, stPnt, edPnt, anisotropy=(1, 1, 1), connectivity=26)

canvas = np.zeros([1, 50, 50], dtype=np.uint8)
cv2.line(canvas[0], stPnt[1:][::-1], edPnt[1:][::-1], color=2)
canvas[path[:, 0], path[:, 1], path[:, 2]] += 1

plt.imshow(canvas[0])

print(f"Euclidean length of dijkstra path: {arclen(path)}")
print(f"Euclidean length of bresenham line: {arclen(np.stack(np.where(canvas & 2 > 0)).T)}")

path = dijkstra3d.dijkstra(weight, stPnt, edPnt, connectivity=26)

canvas = np.zeros([1, 50, 50], dtype=np.uint8)
cv2.line(canvas[0], stPnt[1:][::-1], edPnt[1:][::-1], color=2)
canvas[path[:, 0], path[:, 1], path[:, 2]] += 1

plt.imshow(canvas[0])

print(f"Euclidean length of dijkstra path: {arclen(path)}")
print(f"Euclidean length of bresenham line: {arclen(np.stack(np.where(canvas & 2 > 0)).T)}")
```

Output:
```
Euclidean length of dijkstra path: 61.42640687119285
Euclidean length of bresenham line: 61.426406871192846
Euclidean length of dijkstra path: 66.39696961966999
Euclidean length of bresenham line: 61.426406871192846
```

![image](https://github.com/seung-lab/dijkstra3d/assets/2318046/acff7a82-05a0-43bb-b564-5e7cca4e61f6)

![image](https://github.com/seung-lab/dijkstra3d/assets/2318046/1d4ea0a2-d762-4806-976b-d98a0e5cf578)

